### PR TITLE
[#34] AccountServiceImpl–InitServiceImpl 간 순환 의존성 제거

### DIFF
--- a/src/main/java/dev/syntax/domain/account/controller/AccountController.java
+++ b/src/main/java/dev/syntax/domain/account/controller/AccountController.java
@@ -4,7 +4,6 @@ import dev.syntax.domain.account.dto.AccountItemRes;
 import dev.syntax.domain.account.dto.DepositAccountReq;
 import dev.syntax.domain.account.entity.Account;
 import dev.syntax.domain.account.service.AccountService;
-import dev.syntax.domain.user.service.InitService;
 import dev.syntax.global.response.ApiResponseUtil;
 import dev.syntax.global.response.BaseResponse;
 import dev.syntax.global.response.SuccessCode;
@@ -28,7 +27,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
     private final AccountService accountService;
-    private final InitService initService;
 
     /**
      * 자녀 계좌 생성 API

--- a/src/main/java/dev/syntax/domain/account/service/AccountServiceImpl.java
+++ b/src/main/java/dev/syntax/domain/account/service/AccountServiceImpl.java
@@ -7,7 +7,8 @@ import dev.syntax.domain.account.enums.AccountType;
 import dev.syntax.domain.account.repository.AccountRepository;
 import dev.syntax.domain.account.util.AccountNumberGenerator;
 import dev.syntax.domain.user.entity.CoreUser;
-import dev.syntax.domain.user.service.InitService;
+import dev.syntax.domain.user.repository.CoreUserRelationshipRepository;
+import dev.syntax.domain.user.repository.CoreUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +21,9 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class AccountServiceImpl implements AccountService {
 
+    private final CoreUserRepository coreUserRepository;
+    private final CoreUserRelationshipRepository relationshipRepository;
     private final AccountRepository accountRepository;
-    private final InitService initService;
 
     @Override
     public List<AccountItemRes> getUserAccounts(Long coreUserId) {
@@ -48,7 +50,42 @@ public class AccountServiceImpl implements AccountService {
 
     @Transactional
     public Account createChildDepositAccount(DepositAccountReq req) {
-        CoreUser child = initService.createFamilyRelationship(req);
+        CoreUser child = createFamilyRelationship(req);
         return createDepositAccount(child);
+    }
+
+    /**
+     * 가족 관계를 생성합니다.
+     * <p>
+     * 부모-자녀 간 가족 관계를 매핑합니다. 이미 등록된 관계인 경우 예외를 발생시킵니다.
+     * </p>
+     *
+     * @param req 가족 관계 생성 요청 정보 (부모 ID와 자녀 ID 포함)
+     * @return 가족 관계가 매핑된 자녀 CoreUser 엔티티
+     * @throws dev.syntax.global.exception.BusinessException 부모 또는 자녀를 찾을 수 없는 경우, 이미 가족 관계가 등록된 경우
+     */
+    private CoreUser createFamilyRelationship(DepositAccountReq req) {
+        // 부모 CoreUser 조회
+        CoreUser parent = coreUserRepository.findById(req.parentCoreId())
+                .orElseThrow(() -> new dev.syntax.global.exception.BusinessException(dev.syntax.global.response.error.ErrorBaseCode.PARENT_USER_NOT_FOUND));
+
+        // 자녀 CoreUser 조회
+        CoreUser child = coreUserRepository.findById(req.childCoreId())
+                .orElseThrow(() -> new dev.syntax.global.exception.BusinessException(dev.syntax.global.response.error.ErrorBaseCode.CHILD_USER_NOT_FOUND));
+
+        // 기존 가족 관계 확인
+        boolean relationshipExists = relationshipRepository.existsByParentAndChild(parent, child);
+        if (relationshipExists) {
+            throw new dev.syntax.global.exception.BusinessException(dev.syntax.global.response.error.ErrorBaseCode.CONFLICT);
+        }
+
+        // 가족 관계 매핑
+        dev.syntax.domain.user.entity.CoreUserRelationship relationship = dev.syntax.domain.user.entity.CoreUserRelationship.builder()
+                .parent(parent)
+                .child(child)
+                .build();
+        relationshipRepository.save(relationship);
+
+        return child;
     }
 }

--- a/src/main/java/dev/syntax/domain/user/service/InitService.java
+++ b/src/main/java/dev/syntax/domain/user/service/InitService.java
@@ -1,9 +1,7 @@
 package dev.syntax.domain.user.service;
 
-import dev.syntax.domain.account.dto.DepositAccountReq;
 import dev.syntax.domain.user.dto.ChannelUserInitReq;
 import dev.syntax.domain.user.dto.UserInitRes;
-import dev.syntax.domain.user.entity.CoreUser;
 import dev.syntax.global.exception.BusinessException;
 
 /**
@@ -31,22 +29,4 @@ public interface InitService {
      */
     UserInitRes initChannelUser(ChannelUserInitReq req);
 
-    /**
-     * 가족 관계를 생성합니다.
-     * <p>
-     * 부모-자녀 간 가족 관계를 매핑합니다.
-     * </p>
-     * <ul>
-     *   <li>부모 CoreUser 조회</li>
-     *   <li>자녀 CoreUser 조회</li>
-     *   <li>기존 가족 관계 중복 확인</li>
-     *   <li>가족 관계 매핑 (CoreUserRelationship 생성 및 저장)</li>
-     * </ul>
-     *
-     * @param req 가족 관계 생성 요청 정보 (부모 ID와 자녀 ID 포함)
-     * @return 가족 관계가 매핑된 자녀 CoreUser 엔티티
-     * @throws BusinessException 부모 또는 자녀를 찾을 수 없는 경우 (USER_NOT_FOUND)
-     * @throws BusinessException 이미 가족 관계가 등록된 경우 (CONFLICT)
-     */
-    CoreUser createFamilyRelationship(DepositAccountReq req);
 }

--- a/src/main/java/dev/syntax/domain/user/service/InitServiceImpl.java
+++ b/src/main/java/dev/syntax/domain/user/service/InitServiceImpl.java
@@ -1,7 +1,6 @@
 package dev.syntax.domain.user.service;
 
 import dev.syntax.domain.account.dto.AccountItemRes;
-import dev.syntax.domain.account.dto.DepositAccountReq;
 import dev.syntax.domain.account.entity.Account;
 import dev.syntax.domain.account.service.AccountService;
 import dev.syntax.domain.account.service.BalanceService;
@@ -12,9 +11,7 @@ import dev.syntax.domain.user.dto.ChildUserInitRes;
 import dev.syntax.domain.user.dto.ParentUserInitRes;
 import dev.syntax.domain.user.dto.UserInitRes;
 import dev.syntax.domain.user.entity.CoreUser;
-import dev.syntax.domain.user.entity.CoreUserRelationship;
 import dev.syntax.domain.user.enums.Role;
-import dev.syntax.domain.user.repository.CoreUserRelationshipRepository;
 import dev.syntax.domain.user.repository.CoreUserRepository;
 import dev.syntax.global.exception.BusinessException;
 import dev.syntax.global.response.error.ErrorAuthCode;
@@ -39,7 +36,6 @@ import java.math.BigDecimal;
 public class InitServiceImpl implements InitService {
 
     private final CoreUserRepository coreUserRepository;
-    private final CoreUserRelationshipRepository coreUserRelationshipRepository;
     private final AccountService accountService;
     private final BalanceService balanceService;
 
@@ -130,49 +126,4 @@ public class InitServiceImpl implements InitService {
         return coreUserRepository.save(user);
     }
 
-    /**
-     * 가족 관계를 생성합니다.
-     * <p>
-     * 부모-자녀 간 가족 관계를 매핑합니다. 이미 등록된 관계인 경우 예외를 발생시킵니다.
-     * </p>
-     * <ul>
-     *   <li>부모 CoreUser 조회 및 검증</li>
-     *   <li>자녀 CoreUser 조회 및 검증</li>
-     *   <li>기존 가족 관계 중복 확인</li>
-     *   <li>가족 관계 매핑 (CoreUserRelationship 생성 및 저장)</li>
-     * </ul>
-     *
-     * @param req 가족 관계 생성 요청 정보 (부모 ID와 자녀 ID 포함)
-     * @return 가족 관계가 매핑된 자녀 CoreUser 엔티티
-     * @throws BusinessException 부모 또는 자녀를 찾을 수 없는 경우 (USER_NOT_FOUND)
-     * @throws BusinessException 이미 가족 관계가 등록된 경우 (CONFLICT)
-     */
-    @Transactional
-    @Override
-    public CoreUser createFamilyRelationship(DepositAccountReq req) {
-        // 부모 CoreUser 조회
-        CoreUser parent = coreUserRepository.findById(req.parentCoreId())
-                .orElseThrow(() -> new BusinessException(ErrorBaseCode.PARENT_USER_NOT_FOUND));
-
-        // 자녀 CoreUser 조회
-        CoreUser child = coreUserRepository.findById(req.childCoreId())
-                .orElseThrow(() -> new BusinessException(ErrorBaseCode.CHILD_USER_NOT_FOUND));
-
-        // 기존 가족 관계 확인
-        boolean relationshipExists = coreUserRelationshipRepository.existsByParentAndChild(parent, child);
-        if (relationshipExists) {
-            throw new BusinessException(ErrorBaseCode.CONFLICT);
-        }
-
-        // 가족 관계 매핑
-        CoreUserRelationship relationship = CoreUserRelationship.builder()
-                .parent(parent)
-                .child(child)
-                .build();
-        coreUserRelationshipRepository.save(relationship);
-        log.info("[가족관계 매핑 완료] parentId: {}, childId: {}", parent.getId(), child.getId());
-
-        // 자녀 반환
-        return child;
-    }
 }

--- a/src/test/java/dev/syntax/domain/user/service/InitServiceImplTest.java
+++ b/src/test/java/dev/syntax/domain/user/service/InitServiceImplTest.java
@@ -1,16 +1,12 @@
 package dev.syntax.domain.user.service;
 
-import dev.syntax.domain.account.dto.DepositAccountReq;
-import dev.syntax.domain.account.enums.AccountType;
 import dev.syntax.domain.account.service.AccountService;
 import dev.syntax.domain.account.service.BalanceService;
 import dev.syntax.domain.user.dto.ChannelUserInitReq;
 import dev.syntax.domain.user.dto.ChildUserInitRes;
 import dev.syntax.domain.user.dto.UserInitRes;
 import dev.syntax.domain.user.entity.CoreUser;
-import dev.syntax.domain.user.entity.CoreUserRelationship;
 import dev.syntax.domain.user.enums.Role;
-import dev.syntax.domain.user.repository.CoreUserRelationshipRepository;
 import dev.syntax.domain.user.repository.CoreUserRepository;
 import dev.syntax.global.exception.BusinessException;
 import dev.syntax.global.response.error.ErrorBaseCode;
@@ -19,13 +15,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -46,8 +40,6 @@ class InitServiceImplTest {
     @Mock
     private CoreUserRepository coreUserRepository;
 
-    @Mock
-    private CoreUserRelationshipRepository coreUserRelationshipRepository;
 
     @Mock
     private AccountService accountService;
@@ -158,123 +150,4 @@ class InitServiceImplTest {
         }
     }
 
-    @Nested
-    @DisplayName("가족 관계 생성 테스트")
-    class FamilyRelationshipTest {
-
-        /**
-         * 가족 관계 생성 성공 테스트
-         * <p>
-         * 부모-자녀 간 가족 관계가 정상적으로 매핑되는지 확인합니다.
-         * </p>
-         */
-        @Test
-        @DisplayName("가족 관계 생성 성공")
-        void createFamilyRelationship_success() {
-            // given
-            DepositAccountReq req = new DepositAccountReq(1L, 2L, AccountType.DEPOSIT);
-
-            given(coreUserRepository.findById(1L))
-                    .willReturn(Optional.of(parent));
-            given(coreUserRepository.findById(2L))
-                    .willReturn(Optional.of(child));
-            given(coreUserRelationshipRepository.existsByParentAndChild(parent, child))
-                    .willReturn(false);
-
-            ArgumentCaptor<CoreUserRelationship> relationshipCaptor =
-                    ArgumentCaptor.forClass(CoreUserRelationship.class);
-            given(coreUserRelationshipRepository.save(any(CoreUserRelationship.class)))
-                    .willAnswer(invocation -> invocation.getArgument(0));
-
-            // when
-            CoreUser result = initService.createFamilyRelationship(req);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(2L);
-            assertThat(result.getName()).isEqualTo("자녀");
-
-            verify(coreUserRepository).findById(1L);
-            verify(coreUserRepository).findById(2L);
-            verify(coreUserRelationshipRepository).existsByParentAndChild(parent, child);
-            verify(coreUserRelationshipRepository).save(relationshipCaptor.capture());
-
-            CoreUserRelationship savedRelationship = relationshipCaptor.getValue();
-            assertThat(savedRelationship.getParent().getId()).isEqualTo(1L);
-            assertThat(savedRelationship.getChild().getId()).isEqualTo(2L);
-        }
-
-        /**
-         * 가족 관계 생성 실패 테스트 - 부모를 찾을 수 없음
-         */
-        @Test
-        @DisplayName("가족 관계 생성 실패 - 부모를 찾을 수 없음")
-        void createFamilyRelationship_fail_parentNotFound() {
-            // given
-            DepositAccountReq req = new DepositAccountReq(1L, 2L, AccountType.DEPOSIT);
-
-            given(coreUserRepository.findById(1L))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> initService.createFamilyRelationship(req))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorBaseCode.PARENT_USER_NOT_FOUND.getMessage());
-
-            verify(coreUserRepository).findById(1L);
-            verify(coreUserRepository, never()).findById(2L);
-            verify(coreUserRelationshipRepository, never()).save(any());
-        }
-
-        /**
-         * 가족 관계 생성 실패 테스트 - 자녀를 찾을 수 없음
-         */
-        @Test
-        @DisplayName("가족 관계 생성 실패 - 자녀를 찾을 수 없음")
-        void createFamilyRelationship_fail_childNotFound() {
-            // given
-            DepositAccountReq req = new DepositAccountReq(1L, 2L, AccountType.DEPOSIT);
-
-            given(coreUserRepository.findById(1L))
-                    .willReturn(Optional.of(parent));
-            given(coreUserRepository.findById(2L))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> initService.createFamilyRelationship(req))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorBaseCode.CHILD_USER_NOT_FOUND.getMessage());
-
-            verify(coreUserRepository).findById(1L);
-            verify(coreUserRepository).findById(2L);
-            verify(coreUserRelationshipRepository, never()).save(any());
-        }
-
-        /**
-         * 가족 관계 생성 실패 테스트 - 이미 존재하는 관계
-         */
-        @Test
-        @DisplayName("가족 관계 생성 실패 - 이미 존재하는 관계")
-        void createFamilyRelationship_fail_alreadyExists() {
-            // given
-            DepositAccountReq req = new DepositAccountReq(1L, 2L, AccountType.DEPOSIT);
-
-            given(coreUserRepository.findById(1L))
-                    .willReturn(Optional.of(parent));
-            given(coreUserRepository.findById(2L))
-                    .willReturn(Optional.of(child));
-            given(coreUserRelationshipRepository.existsByParentAndChild(parent, child))
-                    .willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> initService.createFamilyRelationship(req))
-                    .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorBaseCode.CONFLICT.getMessage());
-
-            verify(coreUserRepository).findById(1L);
-            verify(coreUserRepository).findById(2L);
-            verify(coreUserRelationshipRepository).existsByParentAndChild(parent, child);
-            verify(coreUserRelationshipRepository, never()).save(any());
-        }
-    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #34 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- AccountServiceImpl에서 InitService 의존을 제거하고 자녀 가족 등록 로직을 AccountServiceImpl로 이동하여 양방향 순환 참조 문제를 해결함.
