### PR TITLE
[#83, #84] 젠킨스 파이프라인 리팩토링, 배포 파이프라인 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,111 +20,111 @@ pipeline {
                 echo '체크아웃이 완료되었습니다.'
             }
         }
-//
-//         stage('CI : build') {
-//             steps{      // gradlew에 권한을 부여하고 클린 빌드를 수행합니다.
-//                 echo '빌드가 시작되었습니다.'
-//                 echo '해당 단계에서 실패 시 실패 로그를 확인해주세요.'
-//                 sh '''
-//                 set -euxo pipefail
-//                 chmod +x ./gradlew
-//
-//                 ./gradlew clean build
-//                 '''
-//                 echo '빌드가 완료되었습니다.'
-//             }
-//         }
-//
-//         stage('CI : SonarQube analysis') {
-//             steps {     // Jenkins Credential에 저장된 소나큐브 관련 정보를 바탕으로, 정적 분석을 의뢰합니다.
-//                 withSonarQubeEnv('sonarqube-server') {
-//                     echo '정적분석이 시작되었습니다.'
-//                     echo '해당 단계에서 실패 시 소나큐브를 확인해주세요.'
-//                     echo '소나큐브 : 192.168.0.79:8251, ID/PW : 슬랙의 계정 정보 확인'
-//                     sh '''
-//                     set -euxo pipefail
-//                     chmod +x ./gradlew
-//
-//                     ./gradlew sonar -Dsonar.token=$SONAR_AUTH_TOKEN -Dsonar.host.url=$SONAR_HOST_URL
-//                     '''
-//                     echo '정적분석이 완료되었습니다.'
-//                 }
-//             }
-//         }
-//
-//         stage('CI : Quality Gate') {
-//             steps{      // 정적 분석한 리포트를 바탕으로 퀄리티 체크를 수행합니다.
-//                 timeout(time: 1, unit: 'MINUTES') {
-//                     script{
-//                         echo '퀄리티 체크가 시작되었습니다.'
-//                                                 echo '해당 단계에서 실패 시 소나큐브를 확인해주세요.'
-//                                                 echo '소나큐브 : 192.168.0.79:8251, ID/PW : 슬랙의 계정 정보 확인'
-//                         def qg = waitForQualityGate()
-//                         echo "Status: ${qg.status}"
-//                         if(qg.status != 'OK') {
-//                             echo "NOT OK Status: ${qg.status}"
-//                             error "Pipeline aborted due to quality gate failure: ${qg.status}"
-//                         } else{
-//                             echo "status: ${qg.status}"
-//                         }
-//                         echo '퀄리티 체크가 완료되었습니다.'
-//                     }
-//                 }
-//             }
-//         }
-//
-//         stage('CD : main 브랜치 이미지 빌드 & 도커 허브 푸시') {
-//             when {
-//                 anyOf{
-//                     branch 'main'
-//                     branch 'feat/CI-CD'
-//                     branch 'test/jenkins'
-//                 }
-//             }
-//             steps {
-//                 echo 'main branch : 도커 이미지 빌드 & 푸시가 시작되었습니다.'
-//                 echo 'main branch : 해당 단계에서 실패 시 CI/CD 담당자에게 문의해주세요.'
-//                 withCredentials([usernamePassword(
-//                     credentialsId: 'docker-hub',
-//                     usernameVariable: 'REG_USER',
-//                     passwordVariable: 'REG_PASS'
-//                 )]){
-//                     sh(label: 'Docker build & push (latest)', script: '''
-//                         set -euxo pipefail
-//                         echo $REG_PASS | docker login -u $REG_USER --password-stdin
-//                         docker build -t ${MAIN_IMAGE_NAME}:latest .
-//                         docker push  ${MAIN_IMAGE_NAME}:latest
-//                     ''')
-//                 }
-//                 echo 'main branch : 도커 이미지 빌드 & 푸시가 완료되었습니다.'
-//             }
-//         }
-//
-//         stage('CD : dev 브랜치 이미지 빌드 & 도커 허브 푸시') {
-//             when {
-//                 anyOf{
-//                     branch 'dev'
-//                     branch 'test/jenkins'
-//                 }
-//             }
-//             steps {
-//                 echo 'dev branch : 도커 이미지 빌드 & 푸시가 시작되었습니다.'
-//                 echo 'dev branch : 해당 단계에서 실패 시 CI/CD 담당자에게 문의해주세요.'
-//                 withCredentials([usernamePassword(
-//                     credentialsId: 'docker-hub',
-//                     usernameVariable: 'REG_USER',
-//                     passwordVariable: 'REG_PASS'
-//                 )]){
-//                     sh(label: 'Docker build & push (latest)', script: '''
-//                         set -euxo pipefail
-//                         echo $REG_PASS | docker login -u $REG_USER --password-stdin
-//                         docker build -t ${DEV_IMAGE_NAME}:latest .
-//                         docker push  ${DEV_IMAGE_NAME}:latest
-//                     ''')
-//                 }
-//                 echo 'dev branch : 도커 이미지 빌드 & 푸시가 완료되었습니다.'
-//             }
-//         }
+
+        stage('CI : build') {
+            steps{      // gradlew에 권한을 부여하고 클린 빌드를 수행합니다.
+                echo '빌드가 시작되었습니다.'
+                echo '해당 단계에서 실패 시 실패 로그를 확인해주세요.'
+                sh '''
+                set -euxo pipefail
+                chmod +x ./gradlew
+
+                ./gradlew clean build
+                '''
+                echo '빌드가 완료되었습니다.'
+            }
+        }
+
+        stage('CI : SonarQube analysis') {
+            steps {     // Jenkins Credential에 저장된 소나큐브 관련 정보를 바탕으로, 정적 분석을 의뢰합니다.
+                withSonarQubeEnv('sonarqube-server') {
+                    echo '정적분석이 시작되었습니다.'
+                    echo '해당 단계에서 실패 시 소나큐브를 확인해주세요.'
+                    echo '소나큐브 : 192.168.0.79:8251, ID/PW : 슬랙의 계정 정보 확인'
+                    sh '''
+                    set -euxo pipefail
+                    chmod +x ./gradlew
+
+                    ./gradlew sonar -Dsonar.token=$SONAR_AUTH_TOKEN -Dsonar.host.url=$SONAR_HOST_URL
+                    '''
+                    echo '정적분석이 완료되었습니다.'
+                }
+            }
+        }
+
+        stage('CI : Quality Gate') {
+            steps{      // 정적 분석한 리포트를 바탕으로 퀄리티 체크를 수행합니다.
+                timeout(time: 1, unit: 'MINUTES') {
+                    script{
+                        echo '퀄리티 체크가 시작되었습니다.'
+                                                echo '해당 단계에서 실패 시 소나큐브를 확인해주세요.'
+                                                echo '소나큐브 : 192.168.0.79:8251, ID/PW : 슬랙의 계정 정보 확인'
+                        def qg = waitForQualityGate()
+                        echo "Status: ${qg.status}"
+                        if(qg.status != 'OK') {
+                            echo "NOT OK Status: ${qg.status}"
+                            error "Pipeline aborted due to quality gate failure: ${qg.status}"
+                        } else{
+                            echo "status: ${qg.status}"
+                        }
+                        echo '퀄리티 체크가 완료되었습니다.'
+                    }
+                }
+            }
+        }
+
+        stage('CD : main 브랜치 이미지 빌드 & 도커 허브 푸시') {
+            when {
+                anyOf{
+                    branch 'main'
+                    branch 'feat/CI-CD'
+                    branch 'test/jenkins'
+                }
+            }
+            steps {
+                echo 'main branch : 도커 이미지 빌드 & 푸시가 시작되었습니다.'
+                echo 'main branch : 해당 단계에서 실패 시 CI/CD 담당자에게 문의해주세요.'
+                withCredentials([usernamePassword(
+                    credentialsId: 'docker-hub',
+                    usernameVariable: 'REG_USER',
+                    passwordVariable: 'REG_PASS'
+                )]){
+                    sh(label: 'Docker build & push (latest)', script: '''
+                        set -euxo pipefail
+                        echo $REG_PASS | docker login -u $REG_USER --password-stdin
+                        docker build -t ${MAIN_IMAGE_NAME}:latest .
+                        docker push  ${MAIN_IMAGE_NAME}:latest
+                    ''')
+                }
+                echo 'main branch : 도커 이미지 빌드 & 푸시가 완료되었습니다.'
+            }
+        }
+
+        stage('CD : dev 브랜치 이미지 빌드 & 도커 허브 푸시') {
+            when {
+                anyOf{
+                    branch 'dev'
+                    branch 'test/jenkins'
+                }
+            }
+            steps {
+                echo 'dev branch : 도커 이미지 빌드 & 푸시가 시작되었습니다.'
+                echo 'dev branch : 해당 단계에서 실패 시 CI/CD 담당자에게 문의해주세요.'
+                withCredentials([usernamePassword(
+                    credentialsId: 'docker-hub',
+                    usernameVariable: 'REG_USER',
+                    passwordVariable: 'REG_PASS'
+                )]){
+                    sh(label: 'Docker build & push (latest)', script: '''
+                        set -euxo pipefail
+                        echo $REG_PASS | docker login -u $REG_USER --password-stdin
+                        docker build -t ${DEV_IMAGE_NAME}:latest .
+                        docker push  ${DEV_IMAGE_NAME}:latest
+                    ''')
+                }
+                echo 'dev branch : 도커 이미지 빌드 & 푸시가 완료되었습니다.'
+            }
+        }
 
         stage('CD : main 브랜치 이미지를 운영서버에서 배포') {
             when {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #83 , closed #84

## 📝작업 내용

- main 브랜치 : 빌드 후 퀄리티 체크 진행, 이후 운영서버 배포
   - 이 때 설정 파일은 AWS 인스턴스 상에서 관리
   - 관리 위치 : `~/app-config`

- dev 브랜치 : 빌드 후 퀄리티 체크 진행, 이후 온프레미스 서버 배포
   - 이 때 설정 파일은 온프레미스 서버 상에서 관리
   - 관리 위치 : `~/backend`

<img width="1067" height="366" alt="image" src="https://github.com/user-attachments/assets/cb645dae-bf01-48d8-9231-c0e57f463e44" />



> 온프레미스 서버 배포 오류 해결을 위한 젠킨스파일의 도커 명령어 수정

- 젠킨스에 들어있는 도커 컴포즈는 최신 버전 형식인 `docker compose`를 사용하지만, 호스트의 도커가 재설치된 이후 `docker-compose`를 사용해 배포 시 오류가 발생했습니다.
- 원래는 도커 컴포즈의 목표 서버만을 재시작했지만, 불가피하기도 하고, 온프레미스 서버는 테스트만을 위한 용도기 때문에 한번에 컴포즈 구성요소를 모두 run하도록 수정했습니다.
