### PR TITLE
[#98] 소나큐브 주소 안내문구 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                 withSonarQubeEnv('sonarqube-server') {
                     echo '정적분석이 시작되었습니다.'
                     echo '해당 단계에서 실패 시 소나큐브를 확인해주세요.'
-                    echo '소나큐브 : 192.168.0.79:8251, ID/PW : 슬랙의 계정 정보 확인'
+                    echo '소나큐브 : sonarqube.teenyfinny.store, ID/PW : 슬랙의 계정 정보 확인'
                     sh '''
                     set -euxo pipefail
                     chmod +x ./gradlew


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #98 

## 📝작업 내용

- 젠킨스 파이프라인 진행 중 뜨는 안내문구 수정
- 외부에서도 접근 가능한 도메인 주소를 안내하도록 수정