### PR TITLE
[#116] 거래내역 DTO 빠진 필드 추가

### DIFF
--- a/src/main/java/dev/syntax/domain/transaction/dto/TransactionAllowanceItemRes.java
+++ b/src/main/java/dev/syntax/domain/transaction/dto/TransactionAllowanceItemRes.java
@@ -23,7 +23,7 @@ public record TransactionAllowanceItemRes(
         Long transactionId,
         String merchantName,
         BigDecimal amount,
-        TransactionCode code,
+        String code,
         LocalDateTime transactionDate,
         TransactionCategory category,
         BigDecimal balanceAfter

--- a/src/main/java/dev/syntax/domain/transaction/dto/TransactionDetailItemRes.java
+++ b/src/main/java/dev/syntax/domain/transaction/dto/TransactionDetailItemRes.java
@@ -26,6 +26,7 @@ public record TransactionDetailItemRes(
         TransactionType type,
         TransactionCategory category,
         String approveAmount,
-        String balanceAfter
+        String balanceAfter,
+        String code
 ) {
 }

--- a/src/main/java/dev/syntax/domain/transaction/service/TransactionServiceImpl.java
+++ b/src/main/java/dev/syntax/domain/transaction/service/TransactionServiceImpl.java
@@ -130,7 +130,6 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     @Transactional(readOnly = true)
     public TransactionAllowanceHistoryRes getHistoryByPeriod(String number, LocalDate startDate, LocalDate endDate) {
-
         Account account = accountRepository.findByNumber(number)
                 .orElseThrow(() -> new BusinessException(ErrorBaseCode.NOT_FOUND_ENTITY));
         
@@ -139,27 +138,39 @@ public class TransactionServiceImpl implements TransactionService {
         // 조회할 기간의 시작과 끝 날짜 계산 (자정 기준)
         LocalDateTime start = startDate.atStartOfDay();
         LocalDateTime end = endDate.plusDays(1).atStartOfDay();
+        log.info("계산된 조회 기간 - 시작: {}, 종료: {}", start, end);
         
         // 성능 최적화 쿼리 실행 (account ID로 조회)
         List<Transaction> transactions =
                 transactionRepository.findHistoryByPeriod(account.getId(), start, end);
         
         log.info("조회된 거래 건수: {}", transactions.size());
+        
+        if (!transactions.isEmpty()) {
+            log.info("조회된 거래 상세 정보:");
+            transactions.forEach(t -> 
+                log.info("  - ID: {}, 가맹점: {}, 금액: {}, 코드: {}, 일시: {}, 카테고리: {}, 거래후잔액: {}", 
+                    t.getId(), t.getMerchantName(), t.getAmount(), t.getCode(), 
+                    t.getTransactionDate(), t.getCategory(), t.getBalanceAfter())
+            );
+        }
 
         List<TransactionAllowanceItemRes> items = transactions.stream()
                 .map(t -> new TransactionAllowanceItemRes(
                         t.getId(),
                         t.getMerchantName(),
                         t.getAmount(),
-                        TransactionCode.valueOf(t.getCode()),
+                        t.getCode(),
                         t.getTransactionDate(),
                         t.getCategory(),
                         t.getBalanceAfter()
                 ))
                 .toList();
 
-        log.info(items.toString());
-        return new TransactionAllowanceHistoryRes(items, balance);
+        
+        TransactionAllowanceHistoryRes response = new TransactionAllowanceHistoryRes(items, balance);
+        
+        return response;
     }
 
     /**
@@ -176,6 +187,8 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     @Transactional(readOnly = true)
     public TransactionDetailItemRes getTransactionDetail(Long transactionId) {
+        log.info("=== getTransactionDetail 호출됨 ===");
+        log.info("전달받은 transactionId: {}", transactionId);
 
         Transaction transaction = transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new BusinessException(ErrorBaseCode.NOT_FOUND_ENTITY));
@@ -191,14 +204,20 @@ public class TransactionServiceImpl implements TransactionService {
                 java.time.format.DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss");
         String formattedDate = transaction.getTransactionDate().format(dateFormatter);
 
-        return new TransactionDetailItemRes(
+        log.info("포맷팅된 값 - 금액: {}, 승인금액: {}, 거래후잔액: {}, 날짜: {}", 
+                formattedAmount, formattedApproveAmount, formattedBalanceAfter, formattedDate);
+
+        TransactionDetailItemRes response = new TransactionDetailItemRes(
                 transaction.getMerchantName(),
                 formattedAmount,
                 formattedDate,
                 transaction.getType(),
                 transaction.getCategory(),
                 formattedApproveAmount,
-                formattedBalanceAfter
+                formattedBalanceAfter,
+                transaction.getCode()
         );
+
+        return response;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #116

## 📝작업 내용

> 거래 상세 내역 조회 시 일시불/할부를 나타내는 code 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
