### PR TITLE
[#119] 운영서버에서 127.0.0.1에 접근을 못하던 문제 해결

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,6 +228,7 @@ sudo docker run -d \
   -e TZ=Asia/Seoul \
   --restart unless-stopped \
   -e SPRING_PROFILES_ACTIVE=secret \
+  --network host \
   -v /home/ubuntu/app-config/application-secret.yml:/config/application-secret.yml \
   teenyfinny/core:latest
 
@@ -331,6 +332,7 @@ sudo docker run -d \
   -e TZ=Asia/Seoul \
   --restart unless-stopped \
   -e SPRING_PROFILES_ACTIVE=secret \
+  --network host \
   -v /home/ubuntu/app-config/application-secret.yml:/config/application-secret.yml \
   teenyfinny/core:latest
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #119 

## 📝작업 내용

> 운영서버에서 127.0.0.1에 접근을 못하던 문제 해결

- 도커 네트워크 설정을 통해 로컬호스트에 접속할 수 있도록 수정했습니다.