### PR TITLE
[#175] 목표 달성 후 channel에 알림 전송 시 API-KEY 헤더에 포함 

### DIFF
--- a/src/main/java/dev/syntax/global/config/ChannelRestTemplateConfig.java
+++ b/src/main/java/dev/syntax/global/config/ChannelRestTemplateConfig.java
@@ -3,8 +3,10 @@ package dev.syntax.global.config;
 import dev.syntax.global.channel.ChannelApiProperties;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -17,29 +19,26 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class ChannelRestTemplateConfig {
 
-    private final ChannelApiProperties channelApiProperties;
+	private final ChannelApiProperties channelApiProperties;
 
-    /**
-     * Channel 서버 API 호출용 RestTemplate Bean을 생성합니다.
-     * <p>
-     * 모든 요청에 X-API-KEY 헤더를 자동으로 추가합니다.
-     * </p>
-     *
-     * @return Channel 서버 API 호출용 RestTemplate
-     */
+	/**
+	 * Channel 서버 API 호출용 RestTemplate Bean을 생성합니다.
+	 * <p>
+	 * 모든 요청에 X-API-KEY 헤더를 자동으로 추가합니다.
+	 * </p>
+	 *
+	 * @return Channel 서버 API 호출용 RestTemplate
+	 */
 	@Bean
-    public RestTemplate restTemplate() {
-        RestTemplate restTemplate = new RestTemplate();
-
-        restTemplate.getInterceptors().add((request, body, execution) -> {
-            // API-KEY 헤더 추가
-            if (channelApiProperties.getApiKey() != null) {
-                request.getHeaders().add("X-API-KEY", channelApiProperties.getApiKey());
-            }
-            return execution.execute(request, body);
-        });
-
-        return restTemplate;
-    }
+	public RestTemplate restTemplate(RestTemplateBuilder builder) {
+		return builder
+			.additionalInterceptors((request, body, execution) -> {
+				String apiKey = channelApiProperties.getApiKey();
+				if (StringUtils.hasText(apiKey)) {
+					request.getHeaders().add("X-API-KEY", apiKey);
+				}
+				return execution.execute(request, body);
+			})
+			.build();
+	}
 }
-


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #175

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 목표 달성 후 channel에 알림 전송 시 API-KEY를 헤더에 포함 시킴